### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-validate-tag-filter.gemspec
+++ b/fluent-plugin-validate-tag-filter.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "test-unit"
-  spec.add_runtime_dependency "fluentd"
+  spec.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
 end

--- a/lib/fluent/plugin/filter_validate_tag.rb
+++ b/lib/fluent/plugin/filter_validate_tag.rb
@@ -1,6 +1,7 @@
-module Fluent
+require 'fluent/plugin/filter'
+module Fluent::Plugin
   class ValidateTagFilter < Filter
-    Plugin.register_filter('validate_tag', self)
+    Fluent::Plugin.register_filter('validate_tag', self)
 
     config_param :max_length, :integer, default: nil
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,6 +12,7 @@ require 'test/unit'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
+require 'fluent/test/driver/filter'
 unless ENV.has_key?('VERBOSE')
   nulllogger = Object.new
   nulllogger.instance_eval {|obj|

--- a/test/plugin/test_filter_validate_tag.rb
+++ b/test/plugin/test_filter_validate_tag.rb
@@ -2,15 +2,11 @@ require 'helper'
 
 class ValidateTagFilterTest < Test::Unit::TestCase
   def setup
-    if defined?(Fluent::Filter)
-      Fluent::Test.setup
-    else
-      omit("Use Fluentd v0.12 or later.")
-    end
+    Fluent::Test.setup
   end
 
-  def create_driver(conf: '', tag: 'test')
-    Fluent::Test::FilterTestDriver.new(Fluent::ValidateTagFilter, tag).configure(conf)
+  def create_driver(conf: '')
+    Fluent::Test::Driver::Filter.new(Fluent::Plugin::ValidateTagFilter).configure(conf)
   end
 
   def test_valid_queue
@@ -34,18 +30,18 @@ class ValidateTagFilterTest < Test::Unit::TestCase
   private
 
   def assert_allow_tag(conf: '', tag: 'test')
-    d = create_driver(conf: conf, tag: tag)
-    d.run do
-      d.filter("foo" => 1)
+    d = create_driver(conf: conf)
+    d.run(default_tag: tag) do
+      d.feed("foo" => 1)
     end
-    assert_equal({ "foo" => 1 }, d.filtered_as_array[0][2])
+    assert_equal({ "foo" => 1 }, d.filtered[0][1])
   end
 
   def assert_deny_tag(conf: '', tag: 'test')
-    d = create_driver(conf: conf, tag: tag)
-    d.run do
-      d.filter("foo" => 1)
+    d = create_driver(conf: conf)
+    d.run(default_tag: tag) do
+      d.feed("foo" => 1)
     end
-    assert_equal([], d.filtered_as_array)
+    assert_equal([], d.filtered)
   end
 end


### PR DESCRIPTION
I've tried to migrate to use v0.14 Filter Plugin API.
This PR contains major update change and also includes in breaking changes.
If above questions/problems are acceptable or reasonable for you, could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks.